### PR TITLE
Modified to a more terse input by adding the pgs_brief subcommand

### DIFF
--- a/pg-movement/better-df
+++ b/pg-movement/better-df
@@ -1,9 +1,26 @@
 #!/bin/bash
-# required: jq
-# DISCLAIMER: THIS SCRIPT COMES WITH NO WARRANTY OR GUARANTEE
-# OF ANY KIND.
 # 
+# Copyright (c) 2019 Tom Byrne
 #
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+# jq is required for this to work
 # Written by: Tom Byrne
 
 re='^[0-9]+$'

--- a/pg-movement/better-df
+++ b/pg-movement/better-df
@@ -1,34 +1,17 @@
 #!/bin/bash
+# required: jq
+# DISCLAIMER: THIS SCRIPT COMES WITH NO WARRANTY OR GUARANTEE
+# OF ANY KIND.
 # 
-# Copyright (c) 2019 Tom Byrne
 #
-# Permission is hereby granted, free of charge, to any person obtaining a copy
-# of this software and associated documentation files (the "Software"), to deal
-# in the Software without restriction, including without limitation the rights
-# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-# copies of the Software, and to permit persons to whom the Software is
-# furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included in all
-# copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
-#
-# jq is required for this to work
 # Written by: Tom Byrne
 
 re='^[0-9]+$'
 if [[ $1 =~ $re ]] #if the query is an OSD ID
 then
 jq -sr "group_by(.id) | .[] | add | select ( .id == $1 )" \
-<( ceph pg dump -fjson  | \
-jq -r '.pg_stats[] |  select (.up != .acting) |  { id: (.up-.acting)[], on: {id : .pgid, state, last_change} }, { id: (.acting-.up)[], off: {id : .pgid, state, last_change} }' | \
+<( ceph pg dump pgs_brief -fjson  | \
+jq -r '.pg_stats[]? |  select (.up != .acting) |  { id: (.up-.acting)[], on: {id : .pgid, state, last_change} }, { id: (.acting-.up)[], off: {id : .pgid, state, last_change} }' | \
 jq -s 'group_by(.id) | map({"id": .[0].id, "moving_off": map(.off | select ( . != null )), "moving_on": map( .on | select( . != null ))}) | .[] | .off_count = (.moving_off | length) | .on_count = (.moving_on | length)') \
 <( ceph osd df -fjson | \
 jq '.nodes[]') 
@@ -37,8 +20,8 @@ fi
 
 echo "ID        crush  rewgt   size      free    util      PGs   on   off"
 jq -sr 'group_by(.id) | .[] | add | [.name, .crush_weight, .reweight, .kb, .kb_avail, .utilization, .pgs, .on_count, .off_count] | @tsv' \
-<( ceph pg dump -fjson 2>/dev/null | \
-jq -r '.pg_stats[] |  select (.up != .acting) |  { id: (.up-.acting)[], on: .pgid }, { id: (.acting-.up)[], off: .pgid }' | \
+<( ceph pg dump pgs_brief -fjson 2>/dev/null | \
+jq -r '.pg_stats[]? |  select (.up != .acting) |  { id: (.up-.acting)[], on: .pgid }, { id: (.acting-.up)[], off: .pgid }' | \
 jq -s 'group_by(.id) | map({"id": .[0].id, "moving_off": map(.off | select ( . != null )), "moving_on": map( .on | select( . != null ))}) | .[] | .off_count = (.moving_off | length) | .on_count = (.moving_on | length)') \
 <( ceph osd df -fjson | \
 jq '.nodes[]') | \


### PR DESCRIPTION
The script stopped working on Echo because of a too verbose 'ceph pg dump' (converted into json format) input to jq that caused the active manager to crash. By adding the pgs_brief subcommand the json input to jq is much lighter, yet it contains the necessary information to correctly show the pg movements.